### PR TITLE
add plugin"babel-plugin-transform-object-rest-spread" to devDependencies

### DIFF
--- a/vue-template/template/.babelrc
+++ b/vue-template/template/.babelrc
@@ -1,1 +1,7 @@
-{ "presets": ["es2015"] }
+{
+    "presets": ["es2015"],
+    "plugins": ["transform-object-rest-spread"],
+    "ignore": [
+
+    ]
+}

--- a/vue-template/template/package.json
+++ b/vue-template/template/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel-core": "^6.20.0",
     "babel-loader": "^6.2.9",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015": "^6.18.0",
     "css-loader": "^0.26.1",
     "serve": "^1.4.0",


### PR DESCRIPTION
This plugin allows Babel to transform rest properties for object destructuring assignment and spread properties for object literals.
Developers uses ...mapActions ...mapGetters etc in Vuex so we need this plugin to transform the rest properties and spread properties.