### PR TITLE
Add 'prompt' dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chalk": "^1.1.3",
     "npmlog": "^4.0.0",
     "opener": "^1.4.1",
+    "prompt": "^1.0.0",
     "weex-components": "^0.2.0",
     "weex-previewer": "^1.1.3",
     


### PR DESCRIPTION
Hello!

This fixes issue #60.

After `npm install -g weex-toolkit@beta`, I got the error:

```
$ weex init hello-weex
{ Error: Cannot find module 'prompt'
    at Function.Module._resolveFilename (module.js:440:15)
    ...
```

Turns out file [generator.js](https://github.com/weexteam/weex-toolkit/blob/a2bc3fc56f797109bda14c19094b83b2b6674fd2/src/generator.js) does require `prompt`.

This PR fixes the issue by adding the dependency to the package.

Thanks!