### PR TITLE
missing `ip` dependency

### DIFF
--- a/vue-template/template/package.json
+++ b/vue-template/template/package.json
@@ -26,6 +26,7 @@
     "babel-loader": "^6.2.9",
     "babel-preset-es2015": "^6.18.0",
     "css-loader": "^0.26.1",
+    "ip": "^1.1.4",
     "serve": "^1.4.0",
     "vue-loader": "^10.0.2",
     "vue-template-compiler": "^2.1.8",


### PR DESCRIPTION
https://github.com/weexteam/weex-toolkit/blob/dev/vue-template/template/build/init.js#L3

```
weex-vue-demo ➤ npm run serve                                                                                                                                                             

> weex-vue-demo@0.1.0 serve /Users/hongshu/dev/test/weex-vue-demo
> node build/init.js && serve -p 8080

module.js:471
    throw err;
    ^

Error: Cannot find module 'ip'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/hongshu/dev/test/weex-vue-demo/build/init.js:3:24)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```