### PR TITLE
Fixed path for weex-vue-render

### DIFF
--- a/vue-template/template/weex.html
+++ b/vue-template/template/weex.html
@@ -12,7 +12,7 @@
   <style>body::before { content: "1"; height: 1px; overflow: hidden; color: transparent; display: block; }</style>
   <script src="./assets/phantom-limb.js"></script>
   <script src="./node_modules/vue/dist/vue.runtime.js"></script>
-  <script src="./node_modules/weex-vue-render/index.js"></script>
+  <script src="./node_modules/weex-vue-render/dist/index.js"></script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
When you run `npm run serve` the webpage doesn't render anything because it can't find the weex-vue-render module. In this pull request I corrected the file path, so it does work.