### PR TITLE
fix: use chromium to support deprecated customElements api

### DIFF
--- a/packages/@weex/plugins/debug/src/index.js
+++ b/packages/@weex/plugins/debug/src/index.js
@@ -71,7 +71,7 @@ exports.launch = function (ip, port) {
       headless.launchHeadless(`${config.ip}:${config.port}`, open)
     })
   }
-  if (!config.manual) launcher.launchChrome(debuggerURL, config.REMOTE_DEBUG_PORT || 9222)
+  if (!config.manual) launcher.launchChrome(debuggerURL)
 }
 
 exports.reload = function () {

--- a/packages/@weex/plugins/debug/src/link/handlers/entry.js
+++ b/packages/@weex/plugins/debug/src/link/handlers/entry.js
@@ -5,8 +5,6 @@ const { util } = require('../../util')
 const debuggerRouter = Router.get('debugger')
 const opn = require('opn')
 
-
-
 let heartbeatTimer
 const sendHeartbeat = () => {
   heartbeatTimer && clearTimeout(heartbeatTimer)

--- a/packages/@weex/plugins/debug/src/util/launcher.js
+++ b/packages/@weex/plugins/debug/src/util/launcher.js
@@ -1,31 +1,7 @@
 const opn = require('opn')
-
-const pendingList = []
-let pending = false
-const launchChrome = function (url, remoteDebugPort, wait, callback) {
-  if (!pending) {
-    pending = true
-    url = url.replace(/[&*]/g, '\\&')
-    const args = remoteDebugPort > 0 ? ['-remote-debugging-port=' + remoteDebugPort] : null
-    opn(url, args, !!wait).then(cp => {
-      cp.once('close', e => {
-        callback && callback(null)
-        if (pendingList.length > 0) {
-          pending = false
-          pendingList.shift()()
-        }
-      })
-      cp.once('error', err => {
-        pending = false
-        callback && callback(err)
-      })
-    })
-  }
-  else {
-    pendingList.push(function () {
-      launchChrome(url, remoteDebugPort, wait, callback)
-    })
-  }
+const puppeteer = require('puppeteer')
+const launchChrome = function (url) {
+  opn(url, { app: puppeteer._launcher.executablePath() })
 }
 
 module.exports = {


### PR DESCRIPTION
launchChrome 只被调用过一次，用来启动浏览器，打开调试工具的UI，应该是不需要传入远程调试端口和排队启动。
打开调试工具UI的时候使用模拟runtime的chromium，可以兼容旧版本的customElements api
